### PR TITLE
Add scale to AttackRun endpoint.

### DIFF
--- a/loki/api/attacks/routes.py
+++ b/loki/api/attacks/routes.py
@@ -108,7 +108,10 @@ class RunAttack(Resource):
 
             (original_image,
              result_image,
-             difference_image) = run_attack(img, classifier_id, attack_id)
+             difference_image) = run_attack(img,
+                                            classifier_id,
+                                            attack_id,
+                                            scale=4)
 
             original_file = io.BytesIO()
             original_image.save(original_file, format="JPEG")


### PR DESCRIPTION
This outputs higher-quality images from the endpoint.